### PR TITLE
Drycleaned fragCounter input for JaBbA causes drop of SVs during edge selection

### DIFF
--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -819,7 +819,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         # Let's add a proper merging of the 'germline.status'
         germ.file = rpca.1$inf_germ
         germ.file.dt = gUtils::gr2dt(germ.file)
-        cov = data.table::merge.data.table(x = cov, y = germ.file.dt, all.x = T)
+        cov_with_germline_status = data.table::merge.data.table(x = cov, y = germ.file.dt, all.x = T)
 
         # 
         #cov[germline.status == TRUE, foreground := NA]
@@ -834,7 +834,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
     if (is.chr){
         cov = gr.chr(cov)
     }
-    return(cov)
+    return(cov_with_germline_status)
 }
 
 message("Giddy up 4!")

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -838,7 +838,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
     if (is.chr){
         cov = gr.chr(cov)
     }
-    return(cov_with_germline_status)
+    return(cov)
 }
 
 message("Giddy up 4!")

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -811,7 +811,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
 
     # Continuation from Thu, Apr 20, 2023
     # The na.omit line here removes many regions of the coverage GR. Not entirely sure why omit the region if germline.
-    # I think a better logic would be to set the 'foreground' equal to the 'background'.
+    # I think a better logic would be to set the 'foreground' equal to the median of the chromosome.
     if (germline.filter){
 
         # The original logic causes issues as the input fragCounter coverage is not the same length as the drylean PoN.
@@ -825,8 +825,8 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
 
         # Now prepare final output
         cov_with_germline_status = cov_with_germline_status[,-c(6,7,13:15)]     # Remove unneeded lines
-        cov_with_germline_status[germline.status == TRUE, foreground := background]
-        cov_with_germline_status[germline.status == TRUE, foreground.log := background.log]
+        cov_with_germline_status[germline.status == TRUE, foreground := median.chr]
+        cov_with_germline_status[germline.status == TRUE, foreground.log := log(median.chr)]
 
         # This line causes the issue as it removes any GR with a NA value, not just in important variables.
         #cov = na.omit(cov)

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -829,12 +829,12 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         #cov = na.omit(cov)
     }
 
-    cov = dt2gr(cov)
+    #cov = dt2gr(cov)
 
-    if (is.chr){
-        cov = gr.chr(cov)
-    }
-    return(cov_with_germline_status)
+    #if (is.chr){
+    #    cov = gr.chr(cov)
+    #}
+    return(cov)
 }
 
 message("Giddy up 4!")

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -819,8 +819,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         # Let's add a proper merging of the 'germline.status'
         germ.file = rpca.1$inf_germ
         germ.file.dt = gUtils::gr2dt(germ.file)
-        #cov_with_germline_status = merge(cov, germ.file.dt)
-        #cov$germline.status = cov_with_germline_status$germline.status
+        cov_with_germline_status =  data.table::merge.data.table(x = cov, y = germ.file.dt, all.x = T)
 
         # 
         #cov[germline.status == TRUE, foreground := NA]
@@ -835,7 +834,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
     if (is.chr){
         cov = gr.chr(cov)
     }
-    return(germ.file.dt)
+    return(cov)
 }
 
 message("Giddy up 4!")

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -819,7 +819,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         # Let's add a proper merging of the 'germline.status'
         germ.file = rpca.1$inf_germ
         germ.file.dt = gUtils::gr2dt(germ.file)
-        cov_with_germline_status =  data.table::merge.data.table(x = cov, y = germ.file.dt, all.x = T)
+        cov = data.table::merge.data.table(x = cov, y = germ.file.dt, all.x = T)
 
         # 
         #cov[germline.status == TRUE, foreground := NA]

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -819,7 +819,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         # Let's add a proper merging of the 'germline.status'
         germ.file = rpca.1$inf_germ
         germ.file.dt = gUtils::gr2dt(germ.file)
-        cov_with_germline_status = data.table::merge.data.table(x = cov, y = germ.file.dt)
+        cov_with_germline_status = data.table::merge.data.table(x = cov, y = germ.file.dt, by = c("seqnames", "start", "end"), all = T)
 
         # 
         #cov[germline.status == TRUE, foreground := NA]

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -823,8 +823,8 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         cov$germline.status = cov_with_germline_status$germline.status
 
         # 
-        cov[germline.status == TRUE, foreground := NA]
-        cov[germline.status == TRUE, foreground.log := NA]
+        #cov[germline.status == TRUE, foreground := NA]
+        #cov[germline.status == TRUE, foreground.log := NA]
 
         # This line causes the issue as it removes any GR with a NA value, not just in important variables.
         #cov = na.omit(cov)

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -816,10 +816,10 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
 
         # The original logic causes issues as the input fragCounter coverage is not the same length as the drylean PoN.
         # Therefore, the germline.status vector is recycled and overall assigned improperly.
-        germ.file = rpca.1$inf_germ
-
         # Let's add a proper merging of the 'germline.status'
-        cov_with_germline_status = gUtils::dt2gr(cov) %$% germ.file
+        germ.file = rpca.1$inf_germ
+        germ.file.dt = gUtils::gr2dt(germ.file)
+        cov_with_germline_status = merge(cov, germ.file.dt, all.x = T)
         cov$germline.status = cov_with_germline_status$germline.status
 
         # 

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -818,8 +818,10 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         # Therefore, the germline.status vector is recycled and overall assigned improperly.
         # Let's add a proper merging of the 'germline.status'
         germ.file = rpca.1$inf_germ
+        germ.file = gUtils::gr.nochr(germ.file)                 # Need to strip the chr to match the input 'cov'
         germ.file.dt = gUtils::gr2dt(germ.file)
-        cov_with_germline_status = data.table::merge.data.table(x = cov, y = germ.file.dt, by = c("seqnames", "start", "end"), all = T)
+        cov_with_germline_status = data.table::merge.data.table(x = cov, y = germ.file.dt,
+                                                                by = c("seqnames", "start", "end"), all.x = T)
 
         # 
         #cov[germline.status == TRUE, foreground := NA]
@@ -829,12 +831,12 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         #cov = na.omit(cov)
     }
 
-    #cov = dt2gr(cov)
+    cov = dt2gr(cov)
 
-    #if (is.chr){
-    #    cov = gr.chr(cov)
-    #}
-    return(cov)
+    if (is.chr){
+        cov = gr.chr(cov)
+    }
+    return(cov_with_germline_status)
 }
 
 message("Giddy up 4!")

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -819,7 +819,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         germ.file = rpca.1$inf_germ
 
         # Let's add a proper merging of the 'germline.status'
-        cov_with_germline_status = cov %$% germ.file
+        cov_with_germline_status = gUtils::`%$%`(cov, germ.file)
         cov$germline.status = cov_with_germline_status$germline.status
 
         # 

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -820,7 +820,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         germ.file = rpca.1$inf_germ
         germ.file.dt = gUtils::gr2dt(germ.file)
         cov_with_germline_status = merge(cov, germ.file.dt, all.x = T)
-        cov$germline.status = cov_with_germline_status$germline.status
+        #cov$germline.status = cov_with_germline_status$germline.status
 
         # 
         #cov[germline.status == TRUE, foreground := NA]
@@ -835,7 +835,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
     if (is.chr){
         cov = gr.chr(cov)
     }
-    return(cov)
+    return(cov_with_germline_status)
 }
 
 message("Giddy up 4!")

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -819,7 +819,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         germ.file = rpca.1$inf_germ
 
         # Let's add a proper merging of the 'germline.status'
-        cov_with_germline_status = gUtils::`%$%`(cov, germ.file)
+        cov_with_germline_status = gUtils::dt2gr(cov) %$% germ.file
         cov$germline.status = cov_with_germline_status$germline.status
 
         # 

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -819,7 +819,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         # Let's add a proper merging of the 'germline.status'
         germ.file = rpca.1$inf_germ
         germ.file.dt = gUtils::gr2dt(germ.file)
-        cov_with_germline_status = merge(cov, germ.file.dt, all.x = T)
+        #cov_with_germline_status = merge(cov, germ.file.dt)
         #cov$germline.status = cov_with_germline_status$germline.status
 
         # 
@@ -835,7 +835,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
     if (is.chr){
         cov = gr.chr(cov)
     }
-    return(cov_with_germline_status)
+    return(germ.file.dt)
 }
 
 message("Giddy up 4!")

--- a/R/dryclean.R
+++ b/R/dryclean.R
@@ -819,7 +819,7 @@ start_wash_cycle <- function(cov, mc.cores = 1, detergent.pon.path = NA, verbose
         # Let's add a proper merging of the 'germline.status'
         germ.file = rpca.1$inf_germ
         germ.file.dt = gUtils::gr2dt(germ.file)
-        cov_with_germline_status = data.table::merge.data.table(x = cov, y = germ.file.dt, all.x = T)
+        cov_with_germline_status = data.table::merge.data.table(x = cov, y = germ.file.dt)
 
         # 
         #cov[germline.status == TRUE, foreground := NA]


### PR DESCRIPTION
Hello @mskilab,

I see on the `JaBbA` repo that a 'best practices' are in the works so this might have come up in already.
However, I figured it'd best to detail my thoughts and get an opinion on if this is reasonable.

The behavior I am experiencing occurs when using newly drycleaned fragCounter coverage with JaBbA, the algorithm excludes numerous (but not all) junctions due to "both breakpoints are in NA coverage regions". From what I see in the code, this has a direct impact on the edges selected in from the graph and should to be included (those lost include both inter- and intra- chromosomal breakpoints).

My quick assessment was the input SVs were properly read as input and then dropped as the drycleaned fragCounter coverage contained gaps in the coverage where this would lead to a NA value for the foreground. Considering the original fragCounter input (pre-drycleaning) is binned across the entire genome, I suspected there should be no gaps especially after drycleaning (I believed this is one of the reasons for this step).

To see what occurred between the drycleaning and original fragCounter coverage, I ran `start_wash_cycle` changing only the germline filter to FALSE:
```
# Original Run
start_wash_cycle(cov = prewashed_tumor_cov,
		                             mc.cores = 1,
		                             detergent.pon.path = path_to_detergent_pon,
		                             verbose = TRUE,
		                             whole_genome = TRUE,
		                             germline.filter = TRUE)

# Second Run, without germline.filter
start_wash_cycle(cov = prewashed_tumor_cov,
		                             mc.cores = 1,
		                             detergent.pon.path = path_to_detergent_pon,
		                             verbose = TRUE,
		                             whole_genome = TRUE,
		                             germline.filter = FALSE)
```
 
Interestingly, this revealed a drycleaned fragCounter coverage profile with the same number of bins as the input (i.e. there weren't any gaps in the GRanges). Given this change, I searched the code base and found lines 784-806 in dryclean.R:
```
setnames(cov, "signal", "input.read.counts")
cov = cbind(decomposed[[2]], cov)
colnames(cov)[1] = 'foreground.log'
cov[is.na(input.read.counts), foreground.log := NA]
cov[, foreground := exp(foreground.log)]
cov[input.read.counts == 0, foreground := 0]
cov[is.na(input.read.counts), foreground := NA]
cov = cbind(decomposed[[1]], cov)
colnames(cov)[1] = 'background.log'
cov[is.na(input.read.counts), background.log := NA]
cov[, background := exp(background.log) ]
cov[input.read.counts == 0, background := 0]
cov[is.na(input.read.counts), background := NA]
cov[, log.reads := log(input.read.counts)]
cov[is.infinite(log.reads), log.reads := NA]

if (germline.filter){
    germ.file = rpca.1$inf_germ
    cov$germline.status = germ.file$germline.status
    cov[germline.status == TRUE, foreground := NA]
    cov[germline.status == TRUE, foreground.log := NA]
    cov = na.omit(cov)
}
```
The problem is all the NA records in the `cov` object. Under either condition for `germline.filter`, there coverage regions that are evaluated to NA that are used for input in JaBbA which causes issues downstream.

My thought process in solving this two-sided issue was:
- If we are confident to set `foreground == 0` when `input.read.counts == 0`, then a reasonable assumption would be that  in all scenarios where `is.na(input.read.counts) == TRUE` we can should set `foreground` to some small non-zero value. I chose `exp(-5)` as this was the lowest I saw for the range of `foreground.log` in some of my fragCounter cov files.

- The main issue is the NA for segments where `germline.status == TRUE`, while this will achieve the desired effect of not having these FPs appear as enriched SCNAs but something like GISTIC. However, the NAs can cover regions where a somatic SVs breakpoint resides, leading to its exclusion. I reasoned an alternative would be that in all scenarios where  `germline.status == TRUE` we can should set `foreground` to `median.chr`. I feel would achieve the same effect of reducing the potential FP enrichment of SCNAs for these regions in a patient series (with potential exceptions in extreme aneuploidy of single chromosomes perhaps).

After some troubleshooting runs with dryclean and JaBbA, I have gotten stable results in a variety of JaBbA execution parameters. All of these runs have recovered the nearly all of the previous excluded SVs in the model.

I will continue to test but would interested to hear thoughts on this.

Best,
Patrick

